### PR TITLE
fix: Fixes the fetching of GitHub repos

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ if (typeof window !== "undefined") {
   if (posthogKey) {
     posthog.init(posthogKey, {
       api_host:
-        process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://app.posthog.com",
+        process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.posthog.com",
       // Enable debug mode in development
       loaded: (posthog) => {
         if (process.env.NODE_ENV === "development") posthog.debug();


### PR DESCRIPTION
This PR fixes the fetching of GitHub repos in two aspects:
- if there were more than 100 items, the rest of the pages weren't fetched (incomplete list)
- adds to the list the repos where the authenticated user is a collaborator or an organization member

Also updated the PostHog endpoint