### PR TITLE
feat: Adds buttons for guideline parsing & example generation

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -207,9 +207,7 @@ export const Dashboard = (props: {
                 ) : (
                   <LightningBoltIcon className="mr-1" />
                 )}
-                {parsingGuidelines
-                  ? "Parsing Guidelines..."
-                  : "Parse Guidelines"}
+                {parsingGuidelines ? "Parsing Guidelines..." : "Parse Repo"}
               </Button>
             </div>
           )}

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -45,6 +45,20 @@ import { Textarea } from "./ui/textarea";
 import { toast } from "./ui/use-toast.ts";
 import { getAxiosErorrMessage } from "./utils.tsx";
 
+interface GuidelineCreation {
+  order: number;
+  title: string;
+  details: string;
+  repo_id: number;
+}
+
+interface ParsedGuideline {
+  repo_id: number;
+  origin_path: string;
+  title: string;
+  details: string;
+}
+
 export const Dashboard = (props: {
   githubToken: string;
   authToken: string;
@@ -79,7 +93,7 @@ export const Dashboard = (props: {
     guidelines.find((guideline: any) => guideline.id === selectedGuidelineId) ||
     newCreatingGuidline;
 
-  async function registerGuideline(guideline) {
+  async function registerGuideline(guideline: GuidelineCreation) {
     axios
       .post(`${process.env.NEXT_PUBLIC_API_URL}/guidelines/`, guideline, {
         headers: {
@@ -113,16 +127,17 @@ export const Dashboard = (props: {
       .then((res: any) => {
         console.log(res.data);
         // Remove unused information
-        const parsedGuidelines = res.data.map(({ title, details }) => ({
-          title,
-          details,
+        const parsedGuidelines = res.data.map((g: ParsedGuideline) => ({
+          title: g.title,
+          details: g.details,
         }));
         // Add guidelines to table
         setGuidelines([...guidelines, ...parsedGuidelines]);
         // API request
         const initIndex = guidelines.length;
-        res.data.map((g, index: number) =>
+        res.data.map((g: ParsedGuideline, index: number) =>
           registerGuideline({
+            // @ts-ignore
             repo_id: props.selectedRepoId,
             order: initIndex + index,
             title: g.title,

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1,4 +1,12 @@
-import { ArrowLeftIcon, PlusIcon, ReloadIcon } from "@radix-ui/react-icons";
+import {
+  ArrowLeftIcon,
+  CheckIcon,
+  LightningBoltIcon,
+  MagicWandIcon,
+  PlusIcon,
+  ReloadIcon,
+  TrashIcon,
+} from "@radix-ui/react-icons";
 import axios from "axios";
 import { useEffect, useState } from "react";
 
@@ -104,18 +112,32 @@ export const Dashboard = (props: {
           )}
           <CardTitle className="text-4xl mb-4">Guideline Management</CardTitle>
           {!selectedGuideline && (
-            <Button
-              className="mr-4"
-              onClick={() => {
-                setNewCreatingGuidline({
-                  title: "",
-                  details: "",
-                });
-              }}
-            >
-              <PlusIcon className="mr-1" />
-              Create Guideline
-            </Button>
+            <div>
+              <Button
+                className="mr-4"
+                onClick={() => {
+                  setNewCreatingGuidline({
+                    title: "",
+                    details: "",
+                  });
+                }}
+              >
+                <PlusIcon className="mr-1" />
+                Create Guideline
+              </Button>
+              <Button
+                className="mr-4"
+                onClick={() => {
+                  setNewCreatingGuidline({
+                    title: "",
+                    details: "",
+                  });
+                }}
+              >
+                <LightningBoltIcon className="mr-1" />
+                Parse Guidelines
+              </Button>
+            </div>
           )}
         </div>
       </CardHeader>
@@ -288,12 +310,22 @@ export const Dashboard = (props: {
                 {savingGuideline && (
                   <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
                 )}
+                <CheckIcon className="mr-1" />
                 {newCreatingGuidline ? "Create Guideline" : "Save Guideline"}
+              </Button>
+              <Button
+                variant={"outline"}
+                className="mb-4 mr-4"
+                onClick={() => {}}
+              >
+                <MagicWandIcon className="mr-1" />
+                Generate examples
               </Button>
               {!newCreatingGuidline && (
                 <AlertDialog>
                   <AlertDialogTrigger asChild>
                     <Button variant={"outline"} className="mb-4">
+                      <TrashIcon className="mr-1" />
                       Delete Guideline
                     </Button>
                   </AlertDialogTrigger>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -113,12 +113,13 @@ export default function Home() {
           // @ts-ignore
           loadingAuth={(authCode || githubToken) && !authToken}
         />
-        {authToken && repoConnected ? (
+        {authToken && githubToken && repoConnected ? (
           <Dashboard
             className="flex-1"
             selectedRepoId={selectedRepoId}
             authToken={authToken}
             selectedRepoConnected={repoConnected}
+            githubToken={githubToken}
           />
         ) : (
           <Label className="text-2xl w-full h-full items-center justify-center flex">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -88,9 +88,9 @@
 
 .MultiLineCode {
   font-family: monospace;
-  background-color: #f5f5f5;
-  color: black;
+  background-color: rgb(0, 80, 80);
+  color: white;
   padding: 8px;
   border-radius: 4px;
-  white-space: pre-wrap; /* To ensure long lines are wrapped */
+  white-space: pre-wrap;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -85,3 +85,12 @@
     --background-end-rgb: 0, 0, 0;
   }
 }
+
+.MultiLineCode {
+  font-family: monospace;
+  background-color: #f5f5f5;
+  color: black;
+  padding: 8px;
+  border-radius: 4px;
+  white-space: pre-wrap; /* To ensure long lines are wrapped */
+}


### PR DESCRIPTION
This PR introduces the following modifications:
- adds a button to parse guidelines from the github repository
- adds a button to generate examples from a guideline

Here is the popup for example generation:
![image](https://github.com/quack-ai/platform/assets/26927750/fe137116-2f55-4f2e-aae7-91a9515d2d90)
