### PR TITLE
fix: Fixes API interactions and UI of guideline parsing button

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -210,6 +210,7 @@ export const Dashboard = (props: {
             <div>
               <Button
                 className="mr-4"
+                disabled={parsingGuidelines}
                 onClick={() => {
                   setNewCreatingGuidline({
                     title: "",

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -54,7 +54,7 @@ interface GuidelineCreation {
 
 interface ParsedGuideline {
   repo_id: number;
-  origin_path: string;
+  source: string;
   title: string;
   details: string;
 }

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -95,11 +95,18 @@ export const Dashboard = (props: {
 
   async function registerGuideline(guideline: GuidelineCreation) {
     axios
-      .post(`${process.env.NEXT_PUBLIC_API_URL}/guidelines/`, guideline, {
-        headers: {
-          Authorization: "Bearer " + props.authToken,
+      .post(
+        `${process.env.NEXT_PUBLIC_API_URL}/guidelines/`,
+        {
+          ...guideline,
+          github_token: props.githubToken,
         },
-      })
+        {
+          headers: {
+            Authorization: "Bearer " + props.authToken,
+          },
+        },
+      )
       .then((res) => {})
       .catch((e) => {
         toast({
@@ -318,6 +325,7 @@ export const Dashboard = (props: {
                             ...newCreatingGuidline,
                             repo_id: props.selectedRepoId,
                             order: guidelines.length,
+                            github_token: props.githubToken,
                           },
                           {
                             headers: {
@@ -361,6 +369,7 @@ export const Dashboard = (props: {
                           {
                             title: selectedGuideline.title,
                             details: selectedGuideline.details,
+                            github_token: props.githubToken,
                           },
                           {
                             headers: {
@@ -490,6 +499,9 @@ export const Dashboard = (props: {
                                 headers: {
                                   Authorization: "Bearer " + props.authToken,
                                 },
+                                data: {
+                                  github_token: props.githubToken,
+                                },
                               },
                             )
                             .then((res: any) => {
@@ -532,6 +544,7 @@ export const Dashboard = (props: {
                   `${process.env.NEXT_PUBLIC_API_URL}/repos/${props.selectedRepoId}/guidelines/order`,
                   {
                     guideline_ids: order,
+                    github_token: props.githubToken,
                   },
                   {
                     headers: {

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -144,11 +144,12 @@ export const Dashboard = (props: {
             details: g.details,
           }),
         );
+        setParsingGuidelines(false);
       })
       .catch((e) => {
         console.error(e);
+        setParsingGuidelines(false);
       });
-    setParsingGuidelines(false);
   };
 
   useEffect(() => {

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -555,6 +555,7 @@ export const Dashboard = (props: {
             }}
             selectedRepoId={props.selectedRepoId}
             authToken={props.authToken}
+            githubToken={props.githubToken}
             triggerRefetchGuidelines={() => {
               setTriggerGuidelineRefetch(triggerGuidelineRefetch + 1);
             }}

--- a/components/LeftPanel.tsx
+++ b/components/LeftPanel.tsx
@@ -247,8 +247,7 @@ export const LeftPanel = (props: {
                     `${process.env.NEXT_PUBLIC_API_URL}/repos/`,
                     {
                       id: selectedGithubRepo?.id,
-                      owner_id: selectedGithubRepo?.owner?.id,
-                      full_name: selectedGithubRepo?.full_name,
+                      github_token: props.githubToken,
                     },
                     {
                       headers: {
@@ -288,6 +287,9 @@ export const LeftPanel = (props: {
                     {
                       headers: {
                         Authorization: "Bearer " + props.authToken,
+                      },
+                      data: {
+                        github_token: props.githubToken,
                       },
                     },
                   )

--- a/components/ReorderableList.tsx
+++ b/components/ReorderableList.tsx
@@ -34,6 +34,7 @@ import { getAxiosErorrMessage } from "./utils";
 const ReorderableList = (props: {
   onEdit: any;
   authToken: string;
+  githubToken: string;
   selectedRepoId: number | null;
   guidelines: any;
   loadingGuidelines: boolean;
@@ -213,6 +214,9 @@ const ReorderableList = (props: {
                                 {
                                   headers: {
                                     Authorization: "Bearer " + props.authToken,
+                                  },
+                                  data: {
+                                    github_token: props.githubToken,
                                   },
                                 },
                               )


### PR DESCRIPTION
This PR introduces the following modifications:
- reflects the schema change for guideline extraction
- passes down github token for permission check
- fixes UI of the guideline parsing button (reload button & unclickable)
- makes the guideline creation button unclickable while parsing