### PR TITLE
fix: Fixes the guideline display after parsing

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -276,10 +276,12 @@ export const Dashboard = (props: {
                     };
 
                     const guidelineIndex = guidelines.findIndex(
+                      // @ts-ignore
                       (g) => g.id === selectedGuideline.id,
                     );
 
                     const newGuidelines = [...guidelines];
+                    // @ts-ignore
                     newGuidelines.splice(guidelineIndex, 1, newGuideline);
 
                     setGuidelines(newGuidelines);
@@ -307,10 +309,12 @@ export const Dashboard = (props: {
                     };
 
                     const guidelineIndex = guidelines.findIndex(
+                      // @ts-ignore
                       (g) => g.id === selectedGuideline.id,
                     );
 
                     const newGuidelines = [...guidelines];
+                    // @ts-ignore
                     newGuidelines.splice(guidelineIndex, 1, newGuideline);
 
                     setGuidelines(newGuidelines);


### PR DESCRIPTION
This PR fixes the guideline refresh after requesting repo parsing through the API.

Closes #25