### PR TITLE
fix: Forces table reload when the repo is installed

### DIFF
--- a/components/LeftPanel.tsx
+++ b/components/LeftPanel.tsx
@@ -256,6 +256,9 @@ export const LeftPanel = (props: {
                     },
                   )
                   .then((res) => {
+                    setConnectedRepos([...connectedRepos, res.data]);
+                    props.setRepoConnected(res.data);
+                    props.setSelectedRepoId(res.data.id);
                     setRefetchRepoListTrigger(refetchRepoListTrigger + 1);
                   })
                   .catch((e) => {
@@ -268,7 +271,7 @@ export const LeftPanel = (props: {
                   });
               }}
             >
-              {connectedRepo ? "Repo Connected" : "Connect Repo"}
+              {connectedRepo ? "Repo Connected" : "Install Repo"}
             </Button>
           )}
         </div>


### PR DESCRIPTION
This PR forces the reload of the guideline table once the repo is installed.

Closes #35 