### PR TITLE
Fix Typo in README: "PostgreSQL DB" to "PostHog key"

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This file will have to hold the following information:
 
 Optionally, the following information can be added:
 
-- `NEXT_PUBLIC_POSTHOG_KEY`: the key of the [PostHog](https://posthog.com/) platform that will be created.
+- `NEXT_PUBLIC_POSTHOG_KEY`: the project key of your [PostHog](https://posthog.com/) service, for product analytics
 
 So your `.env` file should look like something similar to:
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This file will have to hold the following information:
 
 Optionally, the following information can be added:
 
-- `NEXT_PUBLIC_POSTHOG_KEY`: the name of the [PostgreSQL](https://www.postgresql.org/) database that will be created.
+- `NEXT_PUBLIC_POSTHOG_KEY`: the key of the [PostHog](https://posthog.com/) platform that will be created.
 
 So your `.env` file should look like something similar to:
 


### PR DESCRIPTION
# What does this PR do?

I have addressed the issue regarding a typo in the README where "PostgreSQL DB" was mentioned incorrectly. The correct term should be "PostHog key."

<!-- Remove if not applicable -->

Closes #39