### PR TITLE
chore: Update readme with correct redirect uri examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ In order to run the project, you will need to specific some information, which c
 This file will have to hold the following information:
 
 - `NEXT_PUBLIC_API_URL`: the endpoint of the Quack API you're using
-- `NEXT_PUBLIC_REDIRECT_URI`: the URL the OAuth app redirects to
+- `NEXT_PUBLIC_REDIRECT_URI`: the URL the OAuth app redirects to [`Recommends not to use localhost`](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#loopback-redirect-urls)
 
 Optionally, the following information can be added:
 
@@ -100,7 +100,7 @@ So your `.env` file should look like something similar to:
 
 ```
 NEXT_PUBLIC_API_URL=http://your-quack-api-host.com/api/v1
-NEXT_PUBLIC_REDIRECT_URI=http://localhost:3000/
+NEXT_PUBLIC_REDIRECT_URI=http://127.0.0.1:3000/
 NEXT_PUBLIC_POSTHOG_KEY=phc_my_api_key
 ```
 


### PR DESCRIPTION
# What does this PR do?

Updated NEXT_PUBLIC_REDIRECT_URI example and added a note because github api [does not recommend localhost as redirect url.](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#loopback-redirect-urls)

## Before submitting
- [ ] Was this discussed/approved in a Github [issue](https://github.com/quack-ai/platform/issues?q=is%3Aissue) or a [discussion](https://github.com/quack-ai/platform/discussions)? Please add a link to it if that's the case.
- [x] You have read the [maintainer guidelines](https://github.com/quack-ai/platform/blob/main/CONTRIBUTING.md#submitting-a-pull-request) and followed them in this PR.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/quack-ai/platform/tree/main/docs).
- [ ] Did you write any new necessary tests?